### PR TITLE
Introduces hard-coded temporary "race" (term TBD) controlled vocabulary

### DIFF
--- a/disa_app/static/js/browse_tabulator_biography-formatter.js
+++ b/disa_app/static/js/browse_tabulator_biography-formatter.js
@@ -55,7 +55,7 @@ function getPersonEntryHTML(entry, sr) {
         age_number = (isNaN(ageAsNumber) ? undefined : ageAsNumber),
         ageStatus = (age_number && age_number <= sr.ADULT_CHILD_CUTOFF_AGE ? 'child' : 'adult'),
         age_text = (entry.age === '(not-recorded)' ? undefined : entry.age),
-        race_text = (entry.all_races ? `, described as &ldquo;${entry.all_races}&rdquo;,` : ''),
+        race_text = (entry.all_races ? `, described as &ldquo;${entry.raceDescriptor}&rdquo;,` : ''),
         year = entry.year,
         proNounCap = sexDisplay.pronoun[entry.sex].cap,
         toBe_conj = sexDisplay.pronoun[entry.sex].be_conj;

--- a/disa_app/static/js/browse_tabulator_init-table.js
+++ b/disa_app/static/js/browse_tabulator_init-table.js
@@ -48,11 +48,7 @@ function getTabulatorOptions(sr, showDetailsFunction) {
     { title:'Racial descriptor',      field:'all_races',  sorter:'string',
       headerFilter: 'select',
       headerFilterParams: {
-        values: [ "Asiatic", "Black", "Carolina Indian", "Creole", "Creole", "Dark melattress",
-                  "Dark mulatto", "East India Negro", "East-India Indian", "East-Indian", "Griffon",
-                  "Half Indian", "Half Indian", "Half Negro", "Indian", "Indian Mulatto", "Irish",
-                  "Martha's Vineyard Indian", "Mulatto", "Mustee", "Negro", "Sambo", "Spanish Indian",
-                  "Surinam Indian", "White" ]
+        values: [ "Black", "Indian", "Multi-racial", "White", "Not specified" ]
       }
     },
     // { title:'Age',       field:'description.age',   sorter:'string', headerFilter: true },

--- a/disa_app/static/js/browse_tabulator_json-processor.js
+++ b/disa_app/static/js/browse_tabulator_json-processor.js
@@ -1,5 +1,6 @@
 
 import { cleanString } from './browse_tabulator_clean-string.js';
+import { raceValueMap } from './browse_tabulator_json-processor_race-value-map.js';
 
 // Given the JSON data loaded from the API, 
 // cleans, processes, and prepares that JSON object
@@ -54,7 +55,20 @@ function processJSON(response, sr) {
       .join(', ');
 
     newEntry.all_tribes = newEntry.tribes.join(', ');
-    newEntry.all_races = newEntry.races.join(', ');
+
+    // Stopgap measure to replace source racial terms with categories - July 25, 2022
+    // (@TODO to be replaced by real cleaning of the data)
+
+    newEntry.raceDescriptor = newEntry.races.join(', '); // For biographic display
+    
+    let uniqueRaceDescriptors = new Set();
+    newEntry.races.forEach(raceDescriptor => {
+      if (raceValueMap[raceDescriptor.toLowerCase()]) {
+        raceValueMap[raceDescriptor.toLowerCase()].forEach(r => uniqueRaceDescriptors.add(r))
+      }
+    });
+
+    newEntry.all_races = [...uniqueRaceDescriptors].join(', ');
     newEntry.year = (new Date(entry.reference_data.date_db)).getFullYear();
 
     // Add a derivative field for Enslaved/Enslaver/Other filter

--- a/disa_app/static/js/browse_tabulator_json-processor_race-value-map.js
+++ b/disa_app/static/js/browse_tabulator_json-processor_race-value-map.js
@@ -1,0 +1,224 @@
+
+/*
+
+  This is a quick fake-data-clean to assign categories to the original
+  racial descriptors in the document. Those categories appear in the 
+  UI dropdown.
+
+  @TODO this should be removed once the data is cleaned at the Database itself.
+
+*/
+
+
+export let raceValueMap = {
+  "part african and part indian":[
+    "Multi-racial",
+    "Black",
+    "Indian"
+  ],
+  "carolina indian":[
+    "Indian"
+  ],
+  "creole":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "criollo":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "east india negro":[
+    "Black"
+  ],
+  "half indian":[
+    "Multi-racial",
+    "Indian"
+  ],
+  "indian":[
+    "Indian"
+  ],
+  "indian mulatto":[
+    "Multi-racial",
+    "Indian",
+    "Black"
+  ],
+  "indio":[
+    "Indian"
+  ],
+  "martha's vineyard indian":[
+    "Indian"
+  ],
+  "mestiza":[
+    "Multi-racial",
+    "Indian",
+    "White"
+  ],
+  "mestizo":[
+    "Multi-racial",
+    "Indian",
+    "White"
+  ],
+  "mulatto":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "mustee":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "sambo":[
+    "Black"
+  ],
+  "spanish indian":[
+    "Multi-racial",
+    "White",
+    "Indian"
+  ],
+  "surinam indian":[
+    
+  ],
+  "surrinam indian":[
+    "Indian"
+  ],
+  "west india mulatto":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "white":[
+    "White"
+  ],
+  "unknown":[
+    "Not specified"
+  ],
+  "unspecified":[
+    "Not specified"
+  ],
+  "white":[
+    "White"
+  ],
+  "negro":[
+    "Black"
+  ],
+  "black":[
+    "Black"
+  ],
+  "white indian":[
+    "Multi-racial",
+    "White",
+    "Indian"
+  ],
+  "negro-indian":[
+    "Multi-racial",
+    "Black",
+    "Indian"
+  ],
+  "half negro":[
+    "Multi-racial",
+    "Black"
+  ],
+  "mulatta":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "mixed race":[
+    "Multi-racial"
+  ],
+  "white mother":[
+    "Multi-racial",
+    "White"
+  ],
+  "east-indian":[
+    
+  ],
+  "east-india indian":[
+    
+  ],
+  "dark mulatto":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "\"looks much like an indian\"":[
+    "Indian"
+  ],
+  "\"resembles an indian in colour\"":[
+    "Indian"
+  ],
+  "\"he resembles an indian, as his father was one\"":[
+    "Indian"
+  ],
+  "mulattoe":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "\"has an indian look\"":[
+    "Indian"
+  ],
+  "\"half indian and half irish\"":[
+    "Multi-racial",
+    "Indian",
+    "White"
+  ],
+  "\"half indian (his father being an indian and his mother a white woman)\"":[
+    "Multi-racial",
+    "Indian",
+    "White"
+  ],
+  "\"of dark complection\"":[
+    "Not specified"
+  ],
+  "molattoe":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "\"of a negroe father, and an indian mother\"":[
+    "Multi-racial",
+    "Black",
+    "Indian"
+  ],
+  "molatto":[
+    "Multi-racial",
+    "Black",
+    "White"
+  ],
+  "mustizo":[
+    "Multi-racial"
+  ],
+  "asiatic indian":[
+    
+  ],
+  "\"some what the color of an indian\"":[
+    "Indian"
+  ],
+  "mulatto indian":[
+    "Multi-racial",
+    "Indian"
+  ],
+  "dark melattress or light griffon":[
+    "Multi-racial",
+    "Black"
+  ],
+  "indi":[
+    "Indian"
+  ],
+  "unclear":[
+    "Not specified"
+  ],
+  "indian wench":[
+    "Indian"
+  ],
+  "multi-racial":[
+    "Multi-racial"
+  ],
+  "not specified":[
+    "Not specified"
+  ]
+};


### PR DESCRIPTION
This is in response to criticism of the source descriptors shown in the dropdown filter. This replaces those values with a temporary controlled vocab. The mapping of DB values to that vocab is defined in `browse_tabulator_json-processor_race-value-map.js`. The working doc for that map is found in [this google sheet](https://docs.google.com/spreadsheets/d/1fgGDVx3fwk3mybtqUciRI1iuAQON1GXDv6cX1gTTgDE/edit#gid=2009764625)