### PR TITLE
truncates display

### DIFF
--- a/disa_app/lib/v_data_document_manager.py
+++ b/disa_app/lib/v_data_document_manager.py
@@ -123,6 +123,7 @@ def manage_put( cite_id: str, user_id: int, payload: bytes ) -> dict:
         data_to_process['citation_type_id'] = incoming_data['citation_type_id'] or unspec.id
 
         cite = session.query( models_alch.Citation ).get( cite_id )
+        log.debug( f'cite, ``{cite}``' )
 
         cite.citation_type_id = data_to_process['citation_type_id']
         # doc.zotero_id = data['zotero_id']
@@ -151,7 +152,13 @@ def manage_put( cite_id: str, user_id: int, payload: bytes ) -> dict:
             cite.display = 'Document :: {}'.format(now.strftime('%Y %B %d'))
         else:
             vals = [ v[1] for v in sorted(citation_display) ]
+            log.debug( f'vals for cite_display, ``{vals}``' )
             cite.display = ', '.join(vals + addendums)
+            log.debug( f'ultimate cite.display, ``{cite.display}``' )
+        if len( cite.display ) > 499:
+            log.debug( 'citation-display too long; truncating' )
+            cite.display = f'{cite.display[:495]}...' 
+            log.debug( f'truncated cite.display, ``{cite.display}``' )
         session.add( cite )
         session.commit()
 

--- a/disa_app/tests/test_data_citation.py
+++ b/disa_app/tests/test_data_citation.py
@@ -237,6 +237,69 @@ class Citation_Test( TestCase ):
         ## cleanup
         self.delete_new_citation()
 
+
+
+
+    def test_put_really_long_title_to_trigger_display_truncation(self):
+        """ Checks PUT to `http://127.0.0.1:8000/data/documents/abcd/` with very long title. """
+        ## create citation
+        self.create_new_citation()
+        ## PUT
+        put_url = reverse( 'data_documents_url', kwargs={'doc_id': self.post_resp_id} )
+        log.debug( f'put_url-url, ``{put_url}``' )
+        very_long_title = 'This sentence is 70 characters, including the space after the period. ' * 10
+        log.debug( f'very_long_title, ``{very_long_title}``' )
+        put_payload = {  # same as create, except for `shortTitle`, which was blank
+            'acknowledgements': '',
+            'citation_type_id': 20,  # means the fields below will be 'Book' fields
+            'comments': '',
+            'fields': {
+                'ISBN': '',
+                'abstractNote': '',
+                'accessDate': '',
+                'archive': '',
+                'archiveLocation': '',
+                'author': '',
+                'callNumber': '',
+                'date': '',
+                'edition': '',
+                'extra': '',
+                'language': '',
+                'libraryCatalog': '',
+                'numPages': '',
+                'numberOfVolumes': '',
+                'pages': '',
+                'place': '',
+                'publisher': '',
+                'rights': '',
+                'series': '',
+                'seriesNumber': '',
+                'shortTitle': '', 
+                'title': f'title--{very_long_title}',
+                'url': '',
+                'volume': ''}
+            }
+        jsn = json.dumps( put_payload )
+        put_response = self.client.put( put_url, data=jsn, content_type='application/json' )
+        put_resp_dct = json.loads( put_response.content )
+        log.debug( f'put_resp_dct, ``{pprint.pformat(put_resp_dct)}``' )
+        ## tests
+        self.assertEqual( 200, put_response.status_code )
+        display = put_resp_dct['doc']['citation']
+        log.debug( f'len(display), ``{len(display)}``' )
+        self.assertEqual(
+            True,
+            len(display) < 500
+            )
+        ## cleanup
+        self.delete_new_citation()
+
+
+
+
+
+
+
     ## DELETE ====================
 
     def test_delete_bad(self):


### PR DESCRIPTION
Adresses part of issue #154 . There were two issues: 
- one was a too-long display that's being addressed via truncating the display. 
- the other issue is that a database field needs to have its varchar size increased.